### PR TITLE
Improve `Disposing` and further improvements

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.7-preview</Version>
+        <Version>1.0.7-preview1</Version>
         <PackageIcon>ar_128.png</PackageIcon>
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/RestApiClientSharp</PackageProjectUrl>

--- a/src/RestApiClientSharp/Interfaces/IRestApiClient.cs
+++ b/src/RestApiClientSharp/Interfaces/IRestApiClient.cs
@@ -20,6 +20,13 @@ namespace AndreasReitberger.API.REST.Interfaces
         public static IRestApiClient? Instance { get; set; }
         #endregion
 
+        #region General
+        public int DefaultTimeout { get; set; }
+        public int MinimumCooldown { get; set; }
+        public int RetriesWhenOffline { get; set; }
+        public bool UseRateLimiter { get; set; }
+        #endregion
+
         #region Auth
         Dictionary<string, IAuthenticationHeader> AuthHeaders { get; set; }
         public bool AuthenticationFailed { get; set; }
@@ -29,6 +36,7 @@ namespace AndreasReitberger.API.REST.Interfaces
         public bool IsOnline { get; set; }
         public bool IsConnecting { get; set; }
         public bool IsInitialized { get; set; }
+        public bool IsAccessTokenValid { get; set; }
         #endregion
 
         #region Api

--- a/src/RestApiClientSharp/Interfaces/ITaskCanceledEventArgs.cs
+++ b/src/RestApiClientSharp/Interfaces/ITaskCanceledEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace AndreasReitberger.API.REST.Interfaces
+{
+    public interface ITaskCanceledEventArgs : IRestEventArgs
+    {
+        #region Properties
+        public string? Source { get; set; }
+        public bool CancelationRequested { get; set; }
+        public int Timeout { get; set; }
+        #endregion
+    }
+}

--- a/src/RestApiClientSharp/Models/Events/TaskCanceledEventArgs.cs
+++ b/src/RestApiClientSharp/Models/Events/TaskCanceledEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using AndreasReitberger.API.REST.Interfaces;
+using Newtonsoft.Json;
+
+namespace AndreasReitberger.API.REST.Events
+{
+    public partial class TaskCanceledEventArgs : RestEventArgs, ITaskCanceledEventArgs
+    {
+        #region Properties
+        public string? Source { get; set; }
+        public bool CancelationRequested { get; set; } = false;
+        public int Timeout { get; set; } = -1;
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        #endregion
+    }
+}

--- a/src/RestApiClientSharp/RestApiClient.Clients.cs
+++ b/src/RestApiClientSharp/RestApiClient.Clients.cs
@@ -16,7 +16,7 @@ namespace AndreasReitberger.API.REST
         #region Properties
 
         #region Clients
-
+        
         [ObservableProperty]
         [JsonIgnore, XmlIgnore]
         public partial RestClient? RestClient { get; set; }
@@ -24,7 +24,14 @@ namespace AndreasReitberger.API.REST
         [ObservableProperty]
         [JsonIgnore, XmlIgnore]
         public partial HttpClient? HttpClient { get; set; }
+        
+        /*
+        [JsonIgnore, XmlIgnore]
+        protected RestClient? _restClient;
 
+        [JsonIgnore, XmlIgnore]
+        protected HttpClient? _httpClient;
+        */
 #if !NETFRAMEWORK
         [ObservableProperty]
         [JsonIgnore, XmlIgnore]
@@ -45,6 +52,10 @@ namespace AndreasReitberger.API.REST
         public partial RateLimiter? Limiter { get; set; }
         partial void OnLimiterChanged(RateLimiter? value) => UpdateRestClientInstance();
 #endif
+
+        [ObservableProperty]
+        public partial bool UseRateLimiter { get; set; } = false;
+        partial void OnUseRateLimiterChanged(bool value) => UpdateRestClientInstance();
 
         [ObservableProperty]
         public partial bool AuthenticationFailed { get; set; } = false;

--- a/src/RestApiClientSharp/RestApiClient.Events.cs
+++ b/src/RestApiClientSharp/RestApiClient.Events.cs
@@ -1,6 +1,6 @@
 ﻿using AndreasReitberger.API.REST.Events;
 using AndreasReitberger.API.REST.Interfaces;
-using System.IO;
+using System.Threading.Tasks;
 
 namespace AndreasReitberger.API.REST
 {
@@ -52,6 +52,7 @@ namespace AndreasReitberger.API.REST
                 throw e.Exception ?? throw new Exception(e.Message);
             }
         }
+
         public event EventHandler<RestEventArgs>? RestApiAuthenticationSucceeded;
         protected virtual void OnRestApiAuthenticationSucceeded(RestEventArgs e)
         {
@@ -69,6 +70,16 @@ namespace AndreasReitberger.API.REST
             if (ReThrowOnError)
             {
                 throw e.Exception ?? throw new Exception(e.Message);
+            }
+        }
+
+        public event EventHandler<TaskCanceledEventArgs>? TaskCanceled;
+        protected virtual void OnTaskCanceled(TaskCanceledEventArgs e)
+        {
+            TaskCanceled?.Invoke(this, e);
+            if (ReThrowOnError)
+            {
+                throw e.Exception ?? throw new TaskCanceledException(e.Message);
             }
         }
         #endregion

--- a/src/RestApiClientSharp/RestApiClient.Rest.cs
+++ b/src/RestApiClientSharp/RestApiClient.Rest.cs
@@ -211,6 +211,14 @@ namespace AndreasReitberger.API.REST
                 }
                 catch (TaskCanceledException texp)
                 {
+                    OnTaskCanceled(new()
+                    {
+                        Message = texp.Message,
+                        Uri = fullUri,
+                        Source = nameof(CheckOnlineAsync),
+                        CancelationRequested = cts?.IsCancellationRequested ?? false,
+                        Exception = texp
+                    });
                     // Throws exception on timeout, not actually an error but indicates if the server is reachable.
                     if (!IsOnline)
                     {
@@ -240,6 +248,8 @@ namespace AndreasReitberger.API.REST
                         apiRsponeResult.Exception = toexp;
                     }
                 }
+                cts?.Dispose();
+                cts = null;
             }
             catch (Exception exc)
             {
@@ -338,11 +348,20 @@ namespace AndreasReitberger.API.REST
                 }
                 catch (TaskCanceledException texp)
                 {
+                    apiRsponeResult.Exception = texp;
+                    OnTaskCanceled(new()
+                    {
+                        Message = texp.Message,
+                        Uri = fullUrl,
+                        Source = nameof(CheckOnlineAsync),
+                        CancelationRequested = cts?.IsCancellationRequested ?? false,
+                        Exception = texp
+                    });
                     // Throws exception on timeout, not actually an error but indicates if the server is reachable.
                     if (!IsOnline)
                     {
                         OnError(new UnhandledExceptionEventArgs(texp, false));
-                        apiRsponeResult.Exception = texp;
+                        //apiRsponeResult.Exception = texp;
                     }
                 }
                 catch (HttpRequestException hexp)

--- a/src/RestApiClientSharp/RestApiClient.Static.cs
+++ b/src/RestApiClientSharp/RestApiClient.Static.cs
@@ -1,12 +1,7 @@
 ﻿using AndreasReitberger.API.REST.Interfaces;
-using AndreasReitberger.API.REST.Utilities;
-using System.Net;
-using System.Net.Http;
-using Newtonsoft.Json;
 
 namespace AndreasReitberger.API.REST
 {
-    // Documentation: https://finnhub.io/docs/api
     public partial class RestApiClient : ObservableObject, IRestApiClient
     {
         #region Methods

--- a/src/RestApiClientSharp/RestApiClient.WebSocket.cs
+++ b/src/RestApiClientSharp/RestApiClient.WebSocket.cs
@@ -130,7 +130,7 @@ namespace AndreasReitberger.API.REST
             if (AuthHeaders.Where(kp => kp.Value.Type == AuthenticationTypeTarget.WebSocket || kp.Value.Type == AuthenticationTypeTarget.Both) is var headers)
             {
                 KeyValuePair<string, IAuthenticationHeader> header = headers.FirstOrDefault();
-                if (header.Value.Target == AuthenticationHeaderTarget.UrlSegment)
+                if (header.Value?.Target == AuthenticationHeaderTarget.UrlSegment)
                 {
                     Uri wsUri = new(websocketUri);
                     websocketUri = $"{WebSocketTargetUri}{(!string.IsNullOrEmpty(wsUri.Query) ? "&" : "?")}{header.Key}={header.Value.Token}";

--- a/src/RestApiClientSharp/RestApiConnectionBuilder.cs
+++ b/src/RestApiClientSharp/RestApiConnectionBuilder.cs
@@ -53,6 +53,7 @@ namespace AndreasReitberger.API.REST
             /// <returns><c>RestApiConnectionBuilder</c></returns>
             public RestApiConnectionBuilder WithRateLimiter(bool autoReplenishment, int tokenLimit, int tokensPerPeriod, double replenishmentPeriod, int queueLimit = int.MaxValue)
             {
+                _client.UseRateLimiter = true;
                 _client.Limiter = new TokenBucketRateLimiter(new()
                 {
                     TokenLimit = tokenLimit,


### PR DESCRIPTION
This PR improves the `Dispose` of used objects. Also a new event has been introduce to rise on a `TaskCanceled` exception.

Moreover the `RateLimiter` is disabled for default now. To use it, set `UseRateLimiter` to true or use `WithRateLimiter` from the connection builder.

Fixed #57
Fixed #58
Fixed #59